### PR TITLE
fix: ensure ad request completed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta name="viewport" content="width=655, user-scalable=yes" />
+    <!-- <script src="http://192.168.1.113:8080/console.js"></script> -->
     <script src="https://cdn.jsdelivr.net/npm/can-autoplay@3.0.0/build/can-autoplay.min.js"></script>
     <script src="videoplayer.js"></script>
     <script src="ima-ad-player.js"></script>

--- a/src/ima-player.js
+++ b/src/ima-player.js
@@ -133,6 +133,17 @@ export default class ImaPlayer {
     this._adDisplayContainer.initialize()
   }
 
+  destroy() {
+    if (! this._end) {
+      this._resetMaxDurationTimer()
+      this._adsManager && this._adsManager.stop()
+    }
+
+    this._destroyAdsManager()
+    this._adsLoader && this._adsLoader.destroy()
+    this._adDisplayContainer && this._adDisplayContainer.destroy()
+  }
+
   _userInteraction(next) {
     this.initAdDisplayContainer()
 

--- a/src/ima-player.js
+++ b/src/ima-player.js
@@ -128,9 +128,13 @@ export default class ImaPlayer {
     this._adsLoader && this._adsLoader.contentComplete()
   }
 
-  _userInteraction(next) {
+  initAdDisplayContainer() {
     // Must be done via a user interaction
     this._adDisplayContainer.initialize()
+  }
+
+  _userInteraction(next) {
+    this.initAdDisplayContainer()
 
     if (! this._o.video.load) {
       next()

--- a/src/ima-player.js
+++ b/src/ima-player.js
@@ -7,6 +7,7 @@ export default class ImaPlayer {
   constructor(options) {
     this._configure(options)
     this._evt = new Observable()
+    this._adRequesting = false
     this._adRequested = false
 
     // https://developers.google.com/interactive-media-ads/docs/sdks/html5/v3/apis#ima.ImaSdkSettings.setVpaidMode
@@ -178,7 +179,13 @@ export default class ImaPlayer {
   _requestAd(options) {
     this._end = false
 
-    // Check if ad pre-requested
+    // Check if ad request is pending
+    if (this._adRequesting) {
+      // Ad will autostart if play method called
+      return
+    }
+
+    // Check if ad already requested (pre-request)
     if (this._adRequested) {
       // Start ad only if play method called
       if (this._adPlayIntent) {
@@ -188,7 +195,7 @@ export default class ImaPlayer {
       return
     }
 
-    this._adRequested = true
+    this._adRequesting = true
 
     if (! this._adsLoader) {
       this._makeAdsLoader()
@@ -323,6 +330,10 @@ export default class ImaPlayer {
     this._adsManager = adsManagerLoadedEvent.getAdsManager(this._o.video, adsRenderingSettings)
     this._bindAdsManagerEvents()
 
+    // Ad is ready to be played
+    this._adRequesting = false
+    this._adRequested = true
+
     if (this._adPlayIntent) {
       this._playAd()
     }
@@ -384,6 +395,7 @@ export default class ImaPlayer {
 
     this._end = true
     this._adPlayIntent = false
+    this._adRequesting = false
     this._adRequested = false
     this._resetMaxDurationTimer()
     this._dispatch('ad_end')


### PR DESCRIPTION
* Fix "pre-request" when play() is called too fast after request().
* Add a method to manually initialize ad display container
* Add destroy method (cleanup ima sdk)